### PR TITLE
Glyph map issues

### DIFF
--- a/src/glyphs/bind.ts
+++ b/src/glyphs/bind.ts
@@ -132,6 +132,7 @@ export function bind<
 
   mapGlyphs({
     binding,
+    selector: config.internalSelector,
     chart: config.chart,
   });
 

--- a/src/glyphs/chevron/chevron-rectangle.ts
+++ b/src/glyphs/chevron/chevron-rectangle.ts
@@ -28,7 +28,7 @@ export function chevronRectangle<A extends Annotation, C extends Chart<any>>(
   let patternSelector = selector + "-pattern";
   let patternSelectorInternal = patternSelector + "-internal";
   let rectSelector = selector + "-rect";
-  let rectSelectorInternal = patternSelector + "-internal";
+  let rectSelectorInternal = rectSelector + "-internal";
 
   let outerBinding = bind<A, C, SVGPatternElement>({
     ...config,

--- a/src/glyphs/glyph-map.ts
+++ b/src/glyphs/glyph-map.ts
@@ -13,6 +13,10 @@ export interface GlyphMapping {
    */
   selection: d3.Selection<any, any, any, any>;
   /**
+   * The selector that was assigned to the glyph when it was created.
+   */
+  selector: string;
+  /**
    * A reference to the Chart that the glyph is rendered in.
    */
   chart: Chart<any>;
@@ -34,6 +38,7 @@ export interface GlyphMapConfig<
   E extends Element
 > {
   binding: Binding<A, C, E>;
+  selector: string;
   chart: C;
 }
 
@@ -50,8 +55,22 @@ export function mapGlyphs<
   config.binding.merge.each((d, i, nodes) => {
     idAnnotationMap.set(d.a.id, d.a);
     let glyphMapList = glyphMap.get(d.a.id) || [];
+
+    let selection = d3.select(nodes[i]);
+
+    for (const mapping of glyphMapList) {
+      if (
+        mapping.chart == config.chart &&
+        mapping.selector == config.selector
+      ) {
+        mapping.selection = selection;
+        return;
+      }
+    }
+
     glyphMapList.push({
-      selection: d3.select(nodes[i]),
+      selection,
+      selector: config.selector,
       chart: config.chart,
     });
     glyphMap.set(d.a.id, glyphMapList);

--- a/src/interactivity/hover.ts
+++ b/src/interactivity/hover.ts
@@ -76,7 +76,6 @@ export function hoverBehavior<A extends Annotation, C extends Chart<any>>(
       console.error("No glyph mapping for Annotation ID", ann.id);
       return;
     }
-
     let mouseoverList = getMouseoverList(ann);
     mouseoverList.push(config.mouseover);
     let mouseoutList = getMouseoutList(ann);


### PR DESCRIPTION
This fixes duplicate glyph map issues by reworking the glyph map to include selectors. The queryGlyphMap function has also been reworked to allow queries constrained by any combination of ID, selector, and Chart.