### PR TITLE
Set default text fill color to black

### DIFF
--- a/src/glyphs/text.ts
+++ b/src/glyphs/text.ts
@@ -155,6 +155,7 @@ export class TextModifier<
   constructor(config: TextModifierConfig<A, C>) {
     super(config);
     addToTextMaps(config);
+    this.fillColor = config.fillColor || "black";
     this.strokeColor = config.strokeColor || "none";
     this.textAnchor = config.textAnchor || "left";
     this.fontSize = config.fontSize || 12;


### PR DESCRIPTION
I noticed a strange bug after using d3 brush on a chart, which seems to
set fill=none on the target svg to avoid setting fill=none on the
handful of svg elements that it creates. I really don't like that
behavior.

This fixes the issue for text, but I'll need to make sure there aren't
other places that I'll need to do something similar.