### PR TITLE
Fixed heatmap re-rendering bug

### DIFF
--- a/src/glyphs/plots/heatmap.ts
+++ b/src/glyphs/plots/heatmap.ts
@@ -78,6 +78,7 @@ export class HeatmapModifier<
 
   defaultInitialize() {
     super.defaultInitialize();
+    this.selection.selectAll("rect").remove();
     this.selection
       .selectAll("rect")
       .data((d) => d.a.points)


### PR DESCRIPTION
The issue was that the svg rectangles internally created by the heatmap
were not being properly removed on replacement re-rendering.