### PR TITLE
Skypack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.10.1] - 2022-05-04
+
+### Changed
+
+- Changed TypeScript module option to ESNext
+
 ## [0.10.0] - 2022-05-03
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 .PHONY: build
 build:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,5 @@
-### SODA Makefile
-### ----------------
-### Welcome to the Makefile, we hope you enjoy your stay! Run
-### `make help` for help.
-###
 
-
-## --------------
-## Public Targets
-## --------------
-
-### build
-### -----
-### Build the example app such that TypeScript files are compiled
-### to JavaScript and the example/ directory is bundled into a
-### single asset to be consumed by example/index.html.
-###
 .PHONY: build
 build:
+	rm -rf build
 	npx tsc --build tsconfig.json
-
-### setup
-### -----
-### Install development dependencies, run this first!
-###
-.PHONY: setup
-setup:
-	@npm install --dev
-	@echo "You will also need wget to run the example app"
-
-## ---------------
-## Private Targets
-## ---------------
-
-
-## This lives way down here because it screws up the syntax highlighting
-## for the rest of the file if it's higher up. Basically, we just grep
-## the Makefile for special comments and barf out those lines.
-MAGIC_COMMENT := \#\#\#
-help:
-	@cat Makefile | grep '^$(MAGIC_COMMENT)' | \
-	sed 's/$(MAGIC_COMMENT) //' | sed 's/$(MAGIC_COMMENT)//' | less

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sodaviz/soda",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sodaviz/soda",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
   "name": "@sodaviz/soda",
   "version": "0.10.0",
   "description": "A library for visualizing biological annotation.",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "./dist/index.js",
+  "type": "module",
+  "module": "./dist/index.js",
+  "exports": {
+      "." : "./dist/index.js"
+  },
+  "types": "./dist/index.d.ts",
   "prepublish": "make build",
   "scripts": {
     "test": "test.sh"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@sodaviz/soda",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A library for visualizing biological annotation.",
   "main": "./dist/index.js",
   "type": "module",
   "module": "./dist/index.js",
   "exports": {
-      "." : "./dist/index.js"
+    ".": "./dist/index.js"
   },
   "types": "./dist/index.d.ts",
   "prepublish": "make build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,
-    "module": "CommonJS",
+    "module": "esnext",
     "sourceMap": true,
     "target": "es6"
   },


### PR DESCRIPTION
This changes the TypeScript compiler module option to ESNext, which seems to fix the skypack bundle.